### PR TITLE
Align query transformer with Harmony messaging defaults

### DIFF
--- a/QUERY_TRANSFORMATION_ARCHITECTURE.md
+++ b/QUERY_TRANSFORMATION_ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # Query Transformation System - Complete Architecture
 
+> **Update:** The production system now uses an LLM-led transformation flow with
+> RapidFuzz tool calls. The content below documents the legacy deterministic
+> implementation; see `QUERY_TRANSFORMATION_LLM_DESIGN_NOTE.md` for the current
+> architecture overview.
+
 ## Multi-Format Support & Conversation Robustness
 
 The Query Transformation System is designed to work seamlessly with **both** Harmony format and legacy Jinja2 templates, while being fully robust for multi-turn conversations with dynamic context shifts.

--- a/QUERY_TRANSFORMATION_DESIGN.md
+++ b/QUERY_TRANSFORMATION_DESIGN.md
@@ -2,7 +2,12 @@
 
 ## Executive Summary
 
-The Query Transformation System is a production-grade preliminary preprocessing step that optimizes user queries before they enter the main pipeline. It preserves user intent while ensuring downstream components interpret queries optimally, resulting in higher-quality code generation and improved user experience.
+The query transformation stage has been upgraded from a deterministic,
+rule-based pipeline to an LLM-orchestrated system with explicit RapidFuzz tool
+calls. The LLM now plans transformations, invokes fuzzy matching when schema
+resolution is required, and returns structured metadata for observability. This
+document retains the legacy implementation notes for historical reference; see
+`QUERY_TRANSFORMATION_LLM_DESIGN_NOTE.md` for the current architecture details.
 
 **Key Characteristics:**
 - ✅ Minimal surface area (single insertion point at pipeline entry)

--- a/QUERY_TRANSFORMATION_LLM_DESIGN_NOTE.md
+++ b/QUERY_TRANSFORMATION_LLM_DESIGN_NOTE.md
@@ -1,0 +1,74 @@
+# Query Transformation LLM Integration – Design Note
+
+## Overview
+
+The query transformation stage now uses an LLM-driven planner to optimise user
+questions before they reach downstream pipeline logic. The LLM is prompted with
+explicit tool definitions and can invoke RapidFuzz-backed fuzzy matching to map
+ambiguous user tokens to dataframe schema elements. The previous deterministic
+classification / normalization stack has been removed; intent preservation and
+confidence are delegated to the LLM with strict schema validation in Python.
+
+## Objectives
+
+- Preserve existing pipeline contracts (`QueryTransformationResult`,
+  `QueryTransformationUnit`) while upgrading their implementation.
+- Provide observable, auditable traces of all LLM interactions and tool calls.
+- Keep latency predictable through bounded tool iterations and capped column
+  inventories.
+
+## Architecture
+
+1. **Prompt Template** (`pandasai/pandasai/prompts/templates/query_transformation.tmpl`)
+   - Defines role, objectives, response schema, and available tools.
+   - Enumerates query types and intent labels expected by downstream systems.
+   - Injects context metadata (column inventory, dataframe count, tool history).
+   - Mirrors the Harmony prompt surface for environments that opt into the
+     legacy single-message format.
+
+2. **QueryTransformer** (`pandasai/pandasai/helpers/query_transformer.py`)
+   - Orchestrates iterative LLM calls with bounded tool invocations.
+   - Executes RapidFuzz similarity search (with difflib fallback) and redacts
+     sensitive inputs in stored metadata.
+   - Builds `QueryTransformationResult` with sanitized audit payloads and
+     configurable confidence thresholds.
+
+3. **Pipeline Integration** (`pandasai/pandasai/pipelines/chat/query_transformation.py`)
+   - Caches transformers per `(mode, llm)` pair for reuse.
+   - Logs reasoning snippets, tool counts, and persists LLM traces in the
+      `PipelineContext` for downstream telemetry.
+   - Seeds `current_user_query` so Harmony-enabled LLMs receive the current turn
+     while preserving the legacy prompt when `use_harmony_format=False`.
+
+## Tool Contract
+
+- **rapidfuzz_similarity** – expects `query` and `choices`, optional `limit`
+  and `scorer`. Returns `{engine, matches[]}`. Automatically redacts raw inputs
+  in persisted metadata while giving the LLM access to full context.
+- Additional tools can be added by extending `_execute_tool` and the prompt
+  catalogue without altering the pipeline surface area.
+
+## Resiliency & Safety
+
+- Invalid or missing final responses degrade gracefully to the original query
+  with zero confidence.
+- Tool executions are capped by `max_tool_iterations`; prompts embed the limit
+  to set LLM expectations.
+- Metadata captures raw LLM responses, final payload, and redacted tool inputs
+  for audit purposes.
+
+## Configuration Surface
+
+- Modes (`default`, `conservative`, `aggressive`) map to confidence thresholds
+  and tool-iteration budgets.
+- `QueryTransformerFactory.create_from_config` exposes
+  `confidence_threshold`, `max_tool_iterations`, and `max_candidates` knobs for
+  fine tuning.
+
+## Testing Strategy
+
+- Unit tests cover direct LLM final responses, explicit tool-call flows, and
+  graceful fallback scenarios.
+- RapidFuzz integration is validated via patched mocks to guarantee the
+  similarity engine is invoked when requested by the LLM.
+

--- a/QUERY_TRANSFORMATION_MIGRATION_NOTES.md
+++ b/QUERY_TRANSFORMATION_MIGRATION_NOTES.md
@@ -1,0 +1,49 @@
+# Query Transformation LLM Migration Notes
+
+## Scope
+
+This document summarises operational changes required when upgrading from the
+deterministic query transformation stack to the new LLM + tool orchestration
+flow.
+
+## Key Changes
+
+- **LLM dependency:** `QueryTransformer` now requires an `LLM` instance at
+  construction time. `QueryTransformationUnit` injects `Config.llm`, so ensure
+  deployment configs still provide a valid LLM.
+- **Factory signature:** `QueryTransformerFactory.create_*` helpers now accept
+  the LLM instance as the first argument.
+- **Metadata schema:** Transformation metadata stored in the pipeline context is
+  now LLM-centric (`llm_reasoning`, `tool_invocations`, `final_payload`,
+  `raw_responses`). Downstream consumers relying on legacy fields such as
+  `transformations_applied` must switch to the new keys.
+- **Observability:** Logging includes reasoning snippets and tool counts instead
+  of rule identifiers. Update dashboards or alerts that parsed log strings.
+- **Harmony defaults:** When `Config.use_harmony_format` is enabled the stage now
+  emits multi-message Harmony prompts by default while still honouring the
+  legacy template path when the flag is `False`. Add the optional
+  `harmony_reasoning_levels['query_transformation']` knob to configuration
+  management to tune reasoning depth without affecting other stages.
+
+## Backward Compatibility
+
+- `QueryTransformationResult` retains the same public API; the only addition is
+  an internal `confidence_threshold` field used by
+  `should_apply_transformation()`.
+- If the LLM fails to provide a final response, the system falls back to the
+  original query with confidence `0.0`, matching previous graceful degradation
+  semantics.
+
+## Recommended Actions
+
+1. **Config audit:** Verify every environment sets `Config.llm`. Absence now
+   raises a configuration error when the pipeline initialises.
+2. **Monitoring update:** Adapt dashboards to the new metadata schema and
+   include tool invocation counts to monitor RapidFuzz usage.
+3. **Testing:** Add fixture coverage for multi-iteration tool flows to mirror
+   the new behaviour, especially when custom `max_tool_iterations` values are
+   used.
+4. **Prompt format validation:** Smoke-test both Harmony (default) and legacy
+   prompt modes during rollout to ensure downstream pipelines receive the
+   expected format per environment configuration.
+

--- a/QUERY_TRANSFORMATION_SUMMARY.md
+++ b/QUERY_TRANSFORMATION_SUMMARY.md
@@ -1,520 +1,74 @@
-# Query Transformation System - Implementation Summary
+# Query Transformation System – LLM Upgrade Summary
 
 ## Executive Overview
 
-Successfully designed and implemented a **production-grade query transformation system** that serves as a preliminary preprocessing step in the PandasAI chat pipeline. The system optimizes user queries while preserving intent, integrates seamlessly with both Harmony format and legacy templates, and maintains robustness across multi-turn conversations.
+The query transformation stage now leverages an LLM-orchestrated workflow with
+explicit RapidFuzz-powered tool calls. The upgrade removes legacy rule-based
+normalisation while preserving intent, latency budgets, and the existing
+pipeline contract. Transformations are now traceable through structured LLM
+metadata stored in the `PipelineContext`.
+
+## Implementation Highlights
+
+- **Core Logic** – `pandasai/helpers/query_transformer.py`
+  - Replaced deterministic pipeline with iterative LLM calls and tool handling.
+  - Added audit-friendly metadata, configurable confidence threshold, and
+    bounded tool iterations.
+- **Prompting** – `pandasai/pandasai/prompts/query_transformation_prompt.py`
+  with `templates/query_transformation.tmpl`
+  - Defines tool catalogue, response schema, and context injection rules.
+  - Provides Harmony-format multi-message prompts by default with automatic
+    fallback to the legacy single prompt when configured.
+- **Pipeline Integration** – `pandasai/pandasai/pipelines/chat/query_transformation.py`
+  - Injects configured LLM, caches transformers per `(mode, llm)` pair, and
+    logs reasoning + tool usage.
+- **Examples & Docs** – Updated `query_transformation_example.py` and added
+  `QUERY_TRANSFORMATION_LLM_DESIGN_NOTE.md` plus
+  `QUERY_TRANSFORMATION_MIGRATION_NOTES.md`.
+- **Testing** – New unit suite `pandasai/tests/unit_tests/helpers/test_query_transformer_llm.py`
+  covers final-only flows, tool invocation loops, and graceful fallbacks.
+
+## Behavioural Changes
+
+- LLM responses control query classification, intent labels, and confidence; no
+  regex heuristics remain.
+- Tool invocations are mandatory for schema disambiguation; RapidFuzz is called
+  via the orchestrator with difflib fallback when unavailable.
+- `QueryTransformationResult` now stores `confidence_threshold` for accurate
+  `should_apply_transformation()` decisions and enriches metadata with
+  `llm_reasoning`, `tool_invocations`, `final_payload`, and raw responses.
+- Pipeline context persists the above metadata, enabling downstream telemetry
+  and debugging.
+
+## Configuration Surface
+
+- Factory helpers accept the LLM instance and expose the following knobs:
+  - `confidence_threshold` (float, default 0.7)
+  - `max_tool_iterations` (int, default per mode)
+  - `max_candidates` (int, cap on schema inventory)
+- Modes retain their previous semantics but now map to tool iteration limits:
+  - `conservative`: threshold 0.9, 1 tool iteration
+  - `default`: threshold 0.7, 2 iterations
+  - `aggressive`: threshold 0.5, 3 iterations
+
+## Observability & Safety
+
+- Each run logs query type, intent, confidence, reasoning, and tool counts.
+- Stored metadata redacts sensitive tool arguments (query text, column lists)
+  while capturing outputs for audit trails.
+- Missing or malformed LLM responses trigger graceful degradation to the
+  original query with confidence `0.0`.
+
+## Testing & Quality
+
+- Unit tests validate LLM orchestration, RapidFuzz integration, and fallback
+  behaviour. Tests leverage stub LLMs and patched RapidFuzz hooks for
+  determinism.
+- Examples switched to deterministic `FakeLLM` outputs for local execution.
+
+## Next Steps
+
+- Monitor tool invocation telemetry to tune column inventory limits.
+- Extend the prompt catalogue with additional tools (e.g., aggregation hints)
+  when new downstream requirements emerge.
 
----
-
-## Implementation Details
-
-### Files Created/Modified
-
-#### New Files (4 core, 3 documentation, 1 example)
-
-**Core Implementation:**
-1. **`pandasai/helpers/query_transformer.py`** (550 lines)
-   - Core transformation logic
-   - Query classification (8 types)
-   - Terminology normalization
-   - Context enrichment
-   - Ambiguity resolution
-   - Confidence scoring
-   - Factory patterns (3 modes)
-
-2. **`pandasai/pipelines/chat/query_transformation.py`** (200 lines)
-   - Pipeline integration layer
-   - Configuration-aware execution
-   - Context metadata building
-   - Graceful degradation
-   - Logging integration
-
-**Testing:**
-3. **`pandasai/tests/unit_tests/helpers/test_query_transformer.py`** (400+ lines)
-   - 50+ unit tests
-   - 8 test classes covering all functionality
-   - Edge case coverage
-   - Integration scenarios
-
-4. **`pandasai/tests/unit_tests/pipelines/chat/test_query_transformation.py`** (300+ lines)
-   - 20+ integration tests
-   - Pipeline behavior validation
-   - Configuration testing
-   - Metadata verification
-
-**Documentation:**
-5. **`QUERY_TRANSFORMATION_DESIGN.md`** (comprehensive design doc)
-6. **`QUERY_TRANSFORMATION_ARCHITECTURE.md`** (architecture & multi-turn conversation)
-7. **`QUERY_TRANSFORMATION_SUMMARY.md`** (this file)
-
-**Examples:**
-8. **`query_transformation_example.py`** (9 usage examples)
-
-#### Modified Files (2 - Minimal Surface Area)
-
-1. **`pandasai/pipelines/chat/generate_chat_pipeline.py`**
-   - Added 1 import line
-   - Added 1 pipeline stage (QueryTransformationUnit as first step)
-   - **Total: 2 lines changed**
-
-2. **`pandasai/schemas/df_config.py`**
-   - Added 2 configuration fields:
-     - `enable_query_transformation: bool = True`
-     - `query_transformation_mode: str = "default"`
-   - **Total: 2 lines added**
-
-**Total Surface Area: 4 lines changed across existing codebase**
-
----
-
-## Key Features Implemented
-
-### 1. Query Classification
-- **8 Query Types:** Statistical, Visualization, Filtering, Aggregation, Descriptive, Comparative, Temporal, General
-- **Pattern Matching:** Regex-based keyword detection
-- **Confidence Scoring:** 0.0-1.0 confidence for each classification
-
-### 2. Terminology Normalization
-- **Statistical Synonyms:** average→mean, total→sum, count→how many, etc.
-- **Case-Insensitive:** Handles mixed case inputs
-- **Selective Application:** Only applies to statistical/aggregation queries
-
-### 3. Context Enrichment
-- **Column Detection:** Identifies column references from available schema
-- **Multi-Dataframe Awareness:** Tracks number of dataframes
-- **Entity Extraction:** Detects implicit references and entities
-
-### 4. Ambiguity Resolution
-- **Pronoun Detection:** Identifies it, this, that, these, those
-- **Missing References:** Flags missing dataframe specifications
-- **Temporal Vagueness:** Detects incomplete time references
-
-### 5. Confidence-Based Application
-- **Threshold:** Default 0.7, configurable per mode
-- **Graceful Fallback:** Uses original query if confidence too low
-- **Intent Preservation:** 4 intent levels (PRESERVE_EXACT, ENHANCE_CLARITY, OPTIMIZE_STRUCTURE, ENRICH_CONTEXT)
-
-### 6. Three Transformation Modes
-- **Default:** Balanced (threshold 0.7, all features enabled)
-- **Conservative:** Minimal intervention (threshold 0.9, limited features)
-- **Aggressive:** Maximum optimization (threshold 0.5, all features enabled)
-
-### 7. Format Compatibility
-- **Harmony Format:** ✅ Full support with metadata integration
-- **Jinja2 Templates:** ✅ Full backward compatibility
-- **Both:** ✅ Can be used together or separately
-
-### 8. Conversation Robustness
-- **Multi-Turn Support:** Maintains context across conversation
-- **Context Tracking:** Uses conversation_id and prompt_id
-- **Dynamic Adaptation:** Adjusts to schema changes mid-conversation
-- **Memory Integration:** Works with conversation history
-
----
-
-## Architecture Highlights
-
-### Pipeline Position
-```
-User Query → QueryTransformationUnit → ValidatePipelineInput → CacheLookup → ...
-             ↑ FIRST STAGE (Minimal Surface Area)
-```
-
-### Design Principles Applied
-
-✅ **Minimal Surface Area**
-- Single insertion point at pipeline entry
-- 4 lines changed in existing code
-- Zero breaking changes
-
-✅ **Intent Preservation**
-- Confidence-based transformation application
-- Original query always preserved
-- Fallback to original on low confidence
-
-✅ **Separation of Concerns**
-- User-facing: Original query in conversation history
-- Internal: Transformed query for pipeline processing
-- Metadata: Stored separately in context
-
-✅ **Scalability**
-- O(n) complexity where n = query length
-- Transformer caching (per mode)
-- No external dependencies
-- Thread-safe, stateless transformations
-
-✅ **Maintainability**
-- Modular design (transformer, pipeline unit, config)
-- Clear separation of responsibilities
-- Comprehensive testing (70+ tests)
-- Extensive documentation
-
-✅ **Production-Grade**
-- Graceful error handling
-- Detailed logging
-- Performance optimization (<5ms overhead)
-- Memory efficient (~4KB per request)
-
----
-
-## Integration Flow
-
-### Standard Pipeline Execution
-
-```python
-# 1. User sends query
-agent.chat("What is the average sales by region?")
-
-# 2. ChatPipelineInput created
-input = ChatPipelineInput(
-    query="What is the average sales by region?",
-    output_type="string",
-    conversation_id=uuid,
-    prompt_id=uuid
-)
-
-# 3. QueryTransformationUnit executes (FIRST STAGE)
-result = QueryTransformationUnit().execute(input, context=ctx, logger=log)
-# → query="What is the mean sales by region?" (normalized)
-# → metadata stored in context
-
-# 4. ValidatePipelineInput (validates config)
-# 5. CacheLookup (uses transformed query → better cache hits!)
-# 6. PromptGeneration
-if config.use_harmony_format:
-    # Harmony path: structured messages with transformed query
-    messages = HarmonyMessagesBuilder.for_code_generation(...)
-else:
-    # Jinja2 path: template rendering with transformed query
-    prompt = template.render(query=input.query, ...)
-
-# 7. CodeGenerator → CodeExecution → Result
-```
-
-### Metadata Flow
-
-```python
-# Stored in context after transformation
-context.intermediate_values = {
-    "original_user_query": "What is the average sales by region?",
-    "query_transformation_metadata": {
-        "query_type": "statistical",
-        "intent_level": "enhance_clarity",
-        "confidence_score": 0.95,
-        "detected_entities": {
-            "columns": ["sales", "region"],
-            "dataframe_count": 1
-        },
-        "optimization_hints": []
-    }
-}
-
-# Available to all downstream pipeline stages
-# Can be used for:
-# - Adjusting reasoning levels in Harmony format
-# - Cache optimization
-# - Error context
-# - Logging and monitoring
-```
-
----
-
-## Configuration Examples
-
-### Default (Recommended)
-```python
-config = Config(
-    enable_query_transformation=True,
-    query_transformation_mode="default"
-)
-# → Balanced transformation, 0.7 confidence threshold
-```
-
-### With Harmony Format
-```python
-config = Config(
-    enable_query_transformation=True,
-    query_transformation_mode="default",
-    use_harmony_format=True,
-    harmony_reasoning_levels={
-        "code_generation": "high"
-    }
-)
-# → Full modern stack (transformation + Harmony)
-```
-
-### Conservative Production
-```python
-config = Config(
-    enable_query_transformation=True,
-    query_transformation_mode="conservative"
-)
-# → Minimal intervention, 0.9 confidence threshold
-```
-
-### Disabled (Legacy)
-```python
-config = Config(
-    enable_query_transformation=False
-)
-# → Exact original behavior, zero transformation
-```
-
----
-
-## Testing Coverage
-
-### Unit Tests (50+)
-- Query classification (all 8 types)
-- Terminology normalization (all patterns)
-- Context enrichment (various contexts)
-- Ambiguity resolution (all patterns)
-- Confidence scoring
-- Intent determination
-- Factory patterns (all 3 modes)
-- Edge cases (empty, long, special chars)
-
-### Integration Tests (20+)
-- Pipeline integration
-- Configuration modes
-- Graceful degradation
-- Metadata storage
-- Logging output
-- Transformer caching
-- Multi-turn scenarios
-
-### Test Execution
-```bash
-# Run all tests
-pytest pandasai/tests/unit_tests/helpers/test_query_transformer.py -v
-pytest pandasai/tests/unit_tests/pipelines/chat/test_query_transformation.py -v
-
-# With coverage
-pytest --cov=pandasai.helpers.query_transformer --cov-report=html
-```
-
----
-
-## Performance Characteristics
-
-### Computational Overhead
-- **Per Query:** <5ms (classification + transformation + metadata)
-- **Memory:** ~4KB per request
-- **Caching:** Transformer instances cached (negligible overhead after first use)
-
-### Scalability
-- **Complexity:** O(n) where n = query length
-- **Typical Query (20 words):** <2ms
-- **Long Query (1000 words):** <50ms
-- **Thread-Safe:** No shared mutable state
-
-### Production Metrics
-- **Latency Impact:** <1% of total pipeline time (LLM calls ~1-5 seconds)
-- **Memory Footprint:** <0.1% of typical agent memory usage
-- **CPU Usage:** Negligible (regex + string operations)
-
----
-
-## Extensibility Points
-
-### 1. Adding New Query Types
-```python
-# In QueryType enum
-CUSTOM_TYPE = "custom_type"
-
-# In _classify_query method
-if "custom_keyword" in query:
-    return QueryType.CUSTOM_TYPE
-```
-
-### 2. Adding Normalization Patterns
-```python
-# In STATISTICAL_PATTERNS dict
-r'\b(new_synonym)\b': 'standard_term'
-```
-
-### 3. Custom Transformation Logic
-```python
-class CustomTransformer(QueryTransformer):
-    def _normalize_terminology(self, query, query_type):
-        # Custom logic
-        return super()._normalize_terminology(query, query_type)
-
-# Use in pipeline
-unit = QueryTransformationUnit(transformer=CustomTransformer())
-```
-
-### 4. Custom Context Enrichment
-```python
-# Override _enrich_with_context
-def _enrich_with_context(self, query, query_type, context_metadata):
-    enriched, metadata = super()._enrich_with_context(...)
-    # Add custom enrichment
-    return enriched, metadata
-```
-
----
-
-## Best Practices
-
-### For Production Use
-1. **Start with default mode:** Balanced behavior for most use cases
-2. **Enable verbose logging initially:** Monitor transformation quality
-3. **Track metrics:** Confidence scores, transformation rates, query types
-4. **Use with Harmony format:** Maximum benefit from both systems
-
-### For Development
-1. **Run tests frequently:** Ensure changes don't break transformations
-2. **Test edge cases:** Empty queries, special chars, very long inputs
-3. **Validate confidence thresholds:** Adjust based on your use case
-4. **Monitor false transformations:** Lower threshold if too conservative
-
-### For Debugging
-1. **Enable verbose mode:** See all transformation details
-2. **Check metadata:** Access transformation_metadata in context
-3. **Compare original vs transformed:** Use context.get("original_user_query")
-4. **Test with disabled transformation:** Isolate transformation vs other issues
-
----
-
-## Future Enhancements (Roadmap)
-
-### Phase 2: Advanced Context (3-6 months)
-- Conversation history integration for better ambiguity resolution
-- Cross-query entity linking
-- User preference learning
-
-### Phase 3: ML-Based Enhancement (6-12 months)
-- Trained query classifier (vs regex patterns)
-- Semantic similarity for better normalization
-- Intent prediction models
-
-### Phase 4: Query Intelligence (12+ months)
-- Auto-complete suggestions
-- Query templates
-- Correction suggestions
-- Multi-language support
-
----
-
-## Comparison with Industry Standards
-
-| Feature | PandasAI Query Transform | OpenAI Assistants | LangChain | Semantic Kernel |
-|---------|-------------------------|-------------------|-----------|-----------------|
-| Intent Preservation | ✅ Explicit confidence | ✅ Yes | ✅ Yes | ✅ Yes |
-| Configurable Modes | ✅ 3 modes | ❌ Single | ⚠️ Limited | ⚠️ Limited |
-| Domain-Specific | ✅ Statistical focus | ❌ General | ❌ General | ❌ General |
-| Multi-Turn Support | ✅ Full support | ✅ Yes | ✅ Yes | ✅ Yes |
-| Format-Agnostic | ✅ Harmony + Jinja2 | N/A | ⚠️ Template-specific | ⚠️ Template-specific |
-| Confidence Scoring | ✅ Explicit 0-1 | ⚠️ Implicit | ❌ None | ❌ None |
-| Minimal Surface Area | ✅ 4 lines changed | N/A | ❌ More invasive | ❌ More invasive |
-
----
-
-## Success Metrics
-
-### Quantitative
-- ✅ **Surface Area:** 4 lines changed (target: <10)
-- ✅ **Test Coverage:** 70+ tests (target: 50+)
-- ✅ **Performance:** <5ms overhead (target: <10ms)
-- ✅ **Memory:** <5KB per request (target: <10KB)
-- ✅ **Zero Breaking Changes:** All existing code works unchanged
-
-### Qualitative
-- ✅ **Intent Preservation:** Confidence-based, explicit scoring
-- ✅ **Maintainability:** Modular, well-documented, tested
-- ✅ **Scalability:** O(n) complexity, stateless, cacheable
-- ✅ **Production-Ready:** Error handling, logging, monitoring
-- ✅ **Industry Standards:** Matches/exceeds frontier-level quality
-
----
-
-## Documentation Deliverables
-
-1. **QUERY_TRANSFORMATION_DESIGN.md** - Complete design document
-   - Architecture overview
-   - Design principles
-   - Transformation pipeline stages
-   - Configuration modes
-   - Performance characteristics
-   - Testing strategy
-   - Extensibility guide
-   - Industry comparison
-
-2. **QUERY_TRANSFORMATION_ARCHITECTURE.md** - Multi-format & conversation robustness
-   - Complete pipeline flow diagram
-   - Harmony + Jinja2 integration
-   - Multi-turn conversation handling
-   - Edge case robustness
-   - Context management
-   - Configuration matrix
-
-3. **QUERY_TRANSFORMATION_SUMMARY.md** - Implementation summary (this file)
-   - Files created/modified
-   - Key features
-   - Integration flow
-   - Testing coverage
-   - Best practices
-   - Roadmap
-
-4. **query_transformation_example.py** - Usage examples
-   - 9 complete examples
-   - All configuration modes
-   - Multi-dataframe scenarios
-   - Programmatic access
-   - Debugging techniques
-
----
-
-## Conclusion
-
-Successfully delivered a **production-grade, frontier-level query transformation system** that:
-
-✅ Preserves user intent with explicit confidence scoring
-✅ Integrates seamlessly with both Harmony format and legacy templates
-✅ Handles multi-turn conversations robustly with context awareness
-✅ Minimizes surface area (4 lines changed in existing code)
-✅ Provides comprehensive testing (70+ tests)
-✅ Maintains backward compatibility (zero breaking changes)
-✅ Achieves excellent performance (<5ms overhead)
-✅ Follows modern AI engineering best practices
-✅ Includes extensive documentation and examples
-
-The system is **ready for production deployment** and meets the standards expected in frontier quant trading and big tech environments. The architecture is scalable, maintainable, and designed for long-term evolution with clear extensibility points.
-
----
-
-## Quick Start
-
-```python
-import pandas as pd
-from pandasai import Agent
-from pandasai.schemas.df_config import Config
-from pandasai.llm import OpenAI
-
-# Create dataframe
-df = pd.DataFrame({
-    'region': ['North', 'South', 'East', 'West'],
-    'sales': [1000, 1500, 1200, 1800]
-})
-
-# Configure with query transformation (enabled by default)
-config = Config(
-    llm=OpenAI(api_token="your-api-key"),
-    enable_query_transformation=True,  # Enabled by default
-    query_transformation_mode="default",  # Or "conservative", "aggressive"
-    use_harmony_format=True,  # Optional: use with Harmony format
-    verbose=True  # See transformation logs
-)
-
-# Create agent
-agent = Agent(df, config=config)
-
-# Query with synonym (will be normalized)
-result = agent.chat("What is the average sales by region?")
-# → "average" automatically normalized to "mean" for better code generation
-
-print(result)
-```
-
-**That's it!** Query transformation works automatically with zero additional code required.

--- a/pandasai/pandasai/prompts/base.py
+++ b/pandasai/pandasai/prompts/base.py
@@ -71,7 +71,8 @@ class BasePrompt:
             "generatepythoncodewithsqlprompt": "code_generation",
             "correcterrorprompt": "error_correction",
             "explainprompt": "explanation",
-            "clarificationquestionprompt": "clarification"
+            "clarificationquestionprompt": "clarification",
+            "querytransformationprompt": "query_transformation",
         }
 
         reasoning_type = reasoning_map.get(prompt_class, "default")

--- a/pandasai/pandasai/prompts/query_transformation_prompt.py
+++ b/pandasai/pandasai/prompts/query_transformation_prompt.py
@@ -1,0 +1,139 @@
+"""Prompt template for the query transformation LLM orchestration."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, TYPE_CHECKING
+
+from .base import BasePrompt
+
+if TYPE_CHECKING:
+    from pandasai.helpers.harmony_messages import HarmonyMessages
+    from pandasai.pipelines.pipeline_context import PipelineContext
+
+
+class QueryTransformationPrompt(BasePrompt):
+    """Render prompt for LLM-driven query transformation."""
+
+    template_path = "query_transformation.tmpl"
+
+    def __init__(
+        self,
+        *,
+        context: Any,
+        query: str,
+        column_inventory: List[str],
+        dataframe_count: int,
+        tool_invocations: List[Dict[str, Any]],
+        config: Dict[str, Any],
+    ) -> None:
+        super().__init__(
+            context=context,
+            query=query,
+            column_inventory=column_inventory,
+            dataframe_count=dataframe_count,
+            tool_invocations=tool_invocations,
+            config=config,
+        )
+
+    def to_harmony_messages(self, context: "PipelineContext") -> "HarmonyMessages":
+        """Build Harmony-format messages optimised for multi-turn pipelines."""
+
+        from pandasai.helpers.harmony_messages import HarmonyMessages
+
+        reasoning_level = self.get_reasoning_level(context)
+        messages = HarmonyMessages(reasoning_level)
+
+        config: Dict[str, Any] = self.props.get("config", {})
+        confidence = config.get("confidence_threshold")
+        max_iterations = config.get("max_tool_iterations")
+        column_limit = int(config.get("column_limit", 0)) or None
+
+        column_inventory: List[str] = self.props.get("column_inventory", [])
+        if column_limit is not None:
+            truncated_columns = column_inventory[:column_limit]
+        else:
+            truncated_columns = column_inventory
+
+        dataframe_count = self.props.get("dataframe_count", 0)
+        tool_invocations = self.props.get("tool_invocations", [])
+
+        columns_section = (
+            ", ".join(truncated_columns)
+            if truncated_columns
+            else "<no columns provided>"
+        )
+
+        config_section = [
+            "# EXECUTION CONTROLS:",
+            f"- Confidence threshold: {confidence if confidence is not None else 'inherit pipeline default'}",
+            f"- Max tool iterations: {max_iterations if max_iterations is not None else 'inherit pipeline default'}",
+            f"- Column inventory size: {len(truncated_columns)} of {len(column_inventory)}",
+        ]
+
+        tool_history_lines = []
+        for index, invocation in enumerate(tool_invocations, start=1):
+            name = invocation.get("name", "unknown")
+            args = invocation.get("args", {})
+            result = invocation.get("result", {})
+            tool_history_lines.append(
+                f"{index}. {name} | args={args} | result={result}"
+            )
+
+        tool_history_block = (
+            "\n".join(tool_history_lines) if tool_history_lines else "None"
+        )
+
+        core_identity = (
+            "You are PandasAI's query transformation orchestrator. Rephrase user "
+            "questions only when it measurably improves downstream execution "
+            "while preserving intent and compliance."
+        )
+        messages.add_core_identity(core_identity, reasoning_level)
+
+        task_context = (
+            "# DATA CONTEXT:\n"
+            f"- Dataframes available: {dataframe_count}\n"
+            f"- Column inventory: {columns_section}\n\n"
+            + "\n".join(config_section)
+        )
+        messages.add_task_context(task_context, reasoning_level)
+
+        tool_catalogue = (
+            "# TOOLING:\n"
+            "Use explicit tool calls for schema resolution. Available tool:\n"
+            "- rapidfuzz_similarity(query, choices, limit=5, scorer) → ranked column matches.\n\n"
+            f"# TOOL HISTORY:\n{tool_history_block}"
+        )
+        messages.add_task_context(tool_catalogue, reasoning_level)
+
+        safety_guard = (
+            "SECURITY: Never leak raw column values or PII. Honour latency budgets, "
+            "avoid speculative schema guesses, and degrade gracefully if unsure."
+        )
+        messages.add_safety_guard(safety_guard)
+
+        output_format = (
+            "Respond in JSON within a ```json block. Use {'action': 'call_tool'} when "
+            "tooling is required and {'action': 'final', ...} when complete. Include "
+            "confidence (0-1), query_type, intent, reasoning, and optional metadata."
+        )
+        messages.add_output_format(output_format)
+
+        messages.start_conversation_history()
+
+        memory = getattr(context, "memory", None)
+        if memory:
+            history = memory.get_conversation_only()
+            max_turns = 3
+            if len(history) > max_turns * 2:
+                history = history[-(max_turns * 2) :]
+            for item in history:
+                content = item.get("message", "")
+                if not content:
+                    continue
+                if item.get("is_user"):
+                    messages.add_user_message(content)
+                else:
+                    messages.add_assistant_message(content)
+
+        return messages

--- a/pandasai/pandasai/prompts/templates/query_transformation.tmpl
+++ b/pandasai/pandasai/prompts/templates/query_transformation.tmpl
@@ -1,0 +1,73 @@
+{% set truncated_columns = column_inventory[: config.get('column_limit', 40)] %}
+You are PandasAI's query transformation orchestrator. Optimise the user query for
+downstream code generation without changing intent. Maintain audit-friendly
+reasoning, redact sensitive data, and stay within latency budgets.
+
+## Context
+- Confidence threshold to apply transformation: {{ '%.2f'|format(config.confidence_threshold) }}
+- Maximum tool iterations allowed: {{ config.max_tool_iterations }}
+- Available dataframes: {{ dataframe_count }}
+- Column inventory (deduplicated, limited to {{ truncated_columns|length }}):
+  {% if truncated_columns %}
+  {{ truncated_columns | join(', ') }}
+  {% else %}
+  none provided
+  {% endif %}
+
+## Tool Catalogue
+You can call tools by returning a JSON object in a markdown ```json code block.
+
+1. "rapidfuzz_similarity"
+   - description: compute fuzzy matches between a query fragment and candidate column names using RapidFuzz.
+   - args schema:
+     {
+       "query": string (required),
+       "choices": array<string> (required),
+       "limit": integer (optional, default 5, max {{ config.max_tool_iterations * 5 + 5 }}),
+       "scorer": string (optional, one of ["ratio", "token_sort_ratio", "token_set_ratio"])
+     }
+   - return format: {"engine": "rapidfuzz", "matches": [{"choice": string, "score": float}]}
+
+When you need a tool result, emit:
+```json
+{"action": "call_tool", "tool_name": "rapidfuzz_similarity", "tool_args": {"query": "...", "choices": ["..."]}, "thought": "why this call matters"}
+```
+
+After receiving tool output you will be prompted again with the tool history.
+
+## Tool History
+{% if tool_invocations %}
+{% for invocation in tool_invocations %}
+- Tool: {{ invocation.name }} | Args: {{ invocation.args }} | Result: {{ invocation.result }}
+{% endfor %}
+{% else %}
+- None
+{% endif %}
+
+## Tasks
+1. Normalise terminology only when it improves downstream compatibility.
+2. Resolve schema references using tool calls rather than guessing.
+3. Produce structured metadata for observability.
+
+## Response Schema
+Always respond with a JSON object inside a ```json code block.
+- When finished:
+  {
+    "action": "final",
+    "transformed_query": string,
+    "query_type": one of ["statistical", "visualization", "filtering", "aggregation", "descriptive", "comparative", "temporal", "general"],
+    "intent": one of ["preserve_exact", "enhance_clarity", "optimize_structure", "enrich_context"],
+    "confidence": float between 0 and 1,
+    "reasoning": short explanation (no secrets),
+    "metadata": {
+        "user_hints": optional string,
+        "notes": optional dict,
+        "column_alignment": optional list
+    }
+  }
+- If you must call a tool first, use the call_tool schema above.
+
+Reject unsafe requests silently by preserving the original query with low confidence.
+
+## Original Query
+"""{{ query }}"""

--- a/pandasai/pandasai/schemas/df_config.py
+++ b/pandasai/pandasai/schemas/df_config.py
@@ -17,6 +17,7 @@ class HarmonyReasoningConfig(TypedDict, total=False):
     error_correction: str
     explanation: str
     clarification: str
+    query_transformation: str
     default: str
 
 
@@ -46,6 +47,7 @@ class Config(BaseModel):
         "error_correction": "medium",
         "explanation": "low",
         "clarification": "low",
+        "query_transformation": "medium",
         "default": "medium"
     })
 

--- a/pandasai/tests/unit_tests/helpers/test_query_transformer_llm.py
+++ b/pandasai/tests/unit_tests/helpers/test_query_transformer_llm.py
@@ -1,0 +1,369 @@
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+if "pandasai.__version__" not in sys.modules:
+    stub_version = types.ModuleType("pandasai.__version__")
+    stub_version.__version__ = "0.0.0"
+    sys.modules["pandasai.__version__"] = stub_version
+
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+pandas_stub = types.ModuleType("pandas")
+pandas_stub.DataFrame = type("DataFrame", (), {})
+pandas_stub.Series = type("Series", (), {})
+sys.modules.setdefault("pandas", pandas_stub)
+_pandas_util = types.ModuleType("pandas.util")
+_pandas_util_version = types.ModuleType("pandas.util.version")
+
+
+class _DummyVersion:
+    def __init__(self, version: str):
+        self.version = version
+
+
+_pandas_util_version.Version = _DummyVersion
+_pandas_util.version = _pandas_util_version
+sys.modules.setdefault("pandas.util", _pandas_util)
+sys.modules.setdefault("pandas.util.version", _pandas_util_version)
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+pydantic_stub = types.ModuleType("pydantic")
+pydantic_stub.BaseModel = type("BaseModel", (), {})
+pydantic_stub.Field = lambda *args, **kwargs: None
+pydantic_stub.PrivateAttr = lambda *args, **kwargs: None
+pydantic_stub.ValidationError = type("ValidationError", (Exception,), {})
+
+def _validator_stub(*args, **kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+pydantic_stub.validator = _validator_stub
+sys.modules.setdefault("pydantic", pydantic_stub)
+sys.modules.setdefault("pydantic.v1", pydantic_stub)
+
+jinja2_stub = types.ModuleType("jinja2")
+
+
+class _DummyTemplate:
+    def __init__(self, template: str):
+        self._template = template
+
+    def render(self, **_kwargs):
+        return self._template
+
+
+class _DummyEnvironment:
+    def __init__(self, loader=None):
+        self.loader = loader
+
+    def from_string(self, template: str):
+        return _DummyTemplate(template)
+
+    def get_template(self, _name: str):
+        return _DummyTemplate("")
+
+
+class _DummyLoader:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+jinja2_stub.Environment = _DummyEnvironment
+jinja2_stub.FileSystemLoader = _DummyLoader
+sys.modules.setdefault("jinja2", jinja2_stub)
+sys.modules.setdefault("matplotlib", types.ModuleType("matplotlib"))
+sys.modules.setdefault("matplotlib.pyplot", types.ModuleType("matplotlib.pyplot"))
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+sys.modules.setdefault("duckdb", types.ModuleType("duckdb"))
+sys.modules.setdefault("sqlglot", types.ModuleType("sqlglot"))
+if "sqlalchemy" not in sys.modules:
+    sqlalchemy_stub = types.ModuleType("sqlalchemy")
+    sqlalchemy_stub.asc = lambda *args, **kwargs: None
+    sqlalchemy_stub.create_engine = lambda *args, **kwargs: None
+    sqlalchemy_stub.select = lambda *args, **kwargs: None
+    sqlalchemy_stub.text = lambda *args, **kwargs: None
+    sys.modules["sqlalchemy"] = sqlalchemy_stub
+    engine_stub = types.ModuleType("sqlalchemy.engine")
+    engine_stub.Connection = object
+    sys.modules["sqlalchemy.engine"] = engine_stub
+sys.modules.setdefault("astor", types.ModuleType("astor"))
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+
+from pandasai.helpers.memory import Memory
+from pandasai.helpers.query_transformer import (
+    QueryTransformer,
+    QueryType,
+    TransformationIntent,
+)
+from pandasai.pipelines.chat.query_transformation import QueryTransformationUnit
+from pandasai.pipelines.pipeline_context import PipelineContext
+from pandasai.llm.base import LLM
+from pandasai.llm.fake import FakeLLM
+from pandasai.prompts.query_transformation_prompt import QueryTransformationPrompt
+
+
+class HarmonyAwareLLM(LLM):
+    """LLM stub that captures Harmony vs legacy prompt usage."""
+
+    def __init__(self, output: str):
+        self._output = output
+        self.messages = None
+
+    def call(self, instruction, context=None):
+        if context and context.config.use_harmony_format:
+            harmony_messages = instruction.to_harmony_messages(context)
+            current_query = context.get("current_user_query")
+            if current_query:
+                harmony_messages.add_user_message(current_query)
+            self.messages = harmony_messages.get_messages_for_llm()
+        else:
+            self.messages = instruction.to_string()
+        return self._output
+
+    @property
+    def type(self) -> str:  # pragma: no cover - simple property
+        return "harmony-aware"
+
+
+class DummyConfig:
+    """Minimal config stub for PipelineContext tests."""
+
+    def __init__(self, *, llm: LLM, use_harmony_format: bool):
+        self.llm = llm
+        self.use_harmony_format = use_harmony_format
+        self.enable_cache = False
+        self.enable_query_transformation = True
+        self.query_transformation_mode = "default"
+        self.harmony_reasoning_levels = {
+            "code_generation": "high",
+            "error_correction": "medium",
+            "explanation": "low",
+            "clarification": "low",
+            "query_transformation": "medium",
+            "default": "medium",
+        }
+        self.direct_sql = False
+        self.data_viz_library = ""
+
+
+class SequencedLLM(LLM):
+    """LLM stub that yields predefined responses for successive calls."""
+
+    def __init__(self, outputs):
+        self._outputs = list(outputs)
+        self.last_prompt = None
+
+    def call(self, instruction, context=None):
+        self.last_prompt = instruction.to_string()
+        if not self._outputs:
+            raise RuntimeError("SequencedLLM received more calls than expected")
+        return self._outputs.pop(0)
+
+    @property
+    def type(self) -> str:  # pragma: no cover - simple property
+        return "sequenced"
+
+
+def test_transform_final_without_tool_call():
+    response = """```json
+    {
+      "action": "final",
+      "transformed_query": "Calculate mean of sales",
+      "query_type": "statistical",
+      "intent": "enhance_clarity",
+      "confidence": 0.88,
+      "reasoning": "Normalized terminology",
+      "metadata": {"user_hints": "Mapped average->mean"}
+    }
+    ```"""
+
+    llm = FakeLLM(output=response)
+    transformer = QueryTransformer(llm, confidence_threshold=0.5)
+
+    result = transformer.transform(
+        "What is the average sales?",
+        {"available_columns": ["sales"], "dataframe_count": 1},
+    )
+
+    assert result.transformed_query == "Calculate mean of sales"
+    assert result.query_type == QueryType.STATISTICAL
+    assert result.intent_level == TransformationIntent.ENHANCE_CLARITY
+    assert result.should_apply_transformation() is True
+    assert result.metadata["llm_reasoning"] == "Normalized terminology"
+
+
+def test_transform_executes_tool_call():
+    tool_request = """```json
+    {
+      "action": "call_tool",
+      "tool_name": "rapidfuzz_similarity",
+      "tool_args": {"query": "rev", "choices": ["revenue", "sales"]},
+      "thought": "Match schema column for 'rev'"
+    }
+    ```"""
+
+    final_response = """```json
+    {
+      "action": "final",
+      "transformed_query": "Show revenue statistics",
+      "query_type": "statistical",
+      "intent": "optimize_structure",
+      "confidence": 0.92,
+      "reasoning": "Aligned partial token to revenue column",
+      "metadata": {
+        "column_alignment": [{"query": "rev", "match": "revenue", "score": 99.0}]
+      }
+    }
+    ```"""
+
+    llm = SequencedLLM([tool_request, final_response])
+
+    with patch("pandasai.helpers.query_transformer.process") as mock_process, \
+        patch("pandasai.helpers.query_transformer.fuzz") as mock_fuzz:
+
+        mock_process.extract.return_value = [("revenue", 99.0, None)]
+        mock_fuzz.token_sort_ratio = MagicMock(return_value=99.0)
+
+        transformer = QueryTransformer(llm, max_tool_iterations=1)
+        result = transformer.transform(
+            "rev stats",
+            {"available_columns": ["sales", "revenue"], "dataframe_count": 1},
+        )
+
+    assert result.transformed_query == "Show revenue statistics"
+    assert result.metadata["tool_invocations"]
+    assert result.metadata["tool_invocations"][0]["name"] == "rapidfuzz_similarity"
+    mock_process.extract.assert_called_once()
+    assert result.metadata["final_payload"]["query_type"] == "statistical"
+
+
+def test_transform_falls_back_when_final_missing():
+    tool_request = """```json
+    {
+      "action": "call_tool",
+      "tool_name": "rapidfuzz_similarity",
+      "tool_args": {"query": "col", "choices": []}
+    }
+    ```"""
+
+    llm = SequencedLLM([tool_request])
+    transformer = QueryTransformer(llm, max_tool_iterations=0)
+
+    result = transformer.transform("original", {"available_columns": []})
+
+    assert result.transformed_query == "original"
+    assert result.confidence_score == 0.0
+    assert result.intent_level == TransformationIntent.PRESERVE_EXACT
+
+
+def test_query_transformation_prompt_harmony_messages_include_history():
+    memory = Memory(memory_size=6)
+    memory.add_without_errors("Show me the revenue trend", True)
+    memory.add_without_errors("Provided summary of revenue trend", False)
+
+    config = DummyConfig(llm=FakeLLM(), use_harmony_format=True)
+    context = PipelineContext(dfs=[], config=config, memory=memory)
+
+    prompt = QueryTransformationPrompt(
+        context=context,
+        query="How about growth?",
+        column_inventory=["revenue", "sales", "growth_rate"],
+        dataframe_count=1,
+        tool_invocations=[{"name": "rapidfuzz_similarity", "args": {"query": "rev"}, "result": {"engine": "rapidfuzz"}}],
+        config={
+            "confidence_threshold": 0.8,
+            "max_tool_iterations": 2,
+            "column_limit": 2,
+        },
+    )
+
+    harmony_messages = prompt.to_harmony_messages(context)
+
+    system_messages = harmony_messages.get_system_messages()
+    assert len(system_messages) >= 4
+
+    conversation = harmony_messages.get_conversation_only()
+    assert conversation
+    assert conversation[0].role == "user"
+    assert "revenue trend" in conversation[0].content
+
+
+def test_query_transformation_unit_harmony_flow_uses_messages_and_sets_query():
+    response = """```json
+    {
+      "action": "final",
+      "transformed_query": "What is the total sales?",
+      "query_type": "aggregation",
+      "intent": "enhance_clarity",
+      "confidence": 0.8,
+      "reasoning": "Normalized terminology",
+      "metadata": {}
+    }
+    ```"""
+
+    llm = HarmonyAwareLLM(response)
+    transformer = QueryTransformer(llm, confidence_threshold=0.5)
+
+    config = DummyConfig(llm=llm, use_harmony_format=True)
+    memory = Memory(memory_size=5)
+    memory.add_without_errors("Show me the revenue", True)
+    memory.add_without_errors("Here is the revenue summary", False)
+    context = PipelineContext(dfs=[], config=config, memory=memory)
+
+    class StubLogger:
+        def log(self, *_args, **_kwargs):
+            pass
+
+    unit = QueryTransformationUnit(transformer=transformer)
+    input_payload = SimpleNamespace(query="What is the sales growth?")
+
+    unit.execute(input_payload, context=context, logger=StubLogger())
+
+    assert context.get("current_user_query") == "What is the sales growth?"
+    assert isinstance(llm.messages, list)
+    assert any(
+        msg["role"] == "user" and "Show me the revenue" in msg["content"]
+        for msg in llm.messages
+    )
+    assert any(
+        msg["role"] == "user" and "What is the sales growth?" in msg["content"]
+        for msg in llm.messages
+    )
+
+
+def test_query_transformation_unit_respects_legacy_prompt_format():
+    response = """```json
+    {
+      "action": "final",
+      "transformed_query": "Show revenue summary",
+      "query_type": "descriptive",
+      "intent": "preserve_exact",
+      "confidence": 0.6,
+      "reasoning": "No change needed",
+      "metadata": {}
+    }
+    ```"""
+
+    llm = HarmonyAwareLLM(response)
+    transformer = QueryTransformer(llm, confidence_threshold=0.5)
+
+    config = DummyConfig(llm=llm, use_harmony_format=False)
+    context = PipelineContext(dfs=[], config=config, memory=Memory())
+
+    class StubLogger:
+        def log(self, *_args, **_kwargs):
+            pass
+
+    unit = QueryTransformationUnit(transformer=transformer)
+    input_payload = SimpleNamespace(query="Show revenue summary")
+
+    unit.execute(input_payload, context=context, logger=StubLogger())
+
+    assert isinstance(llm.messages, str)
+    assert context.get("query_transformation_prompt_format") == "legacy"


### PR DESCRIPTION
## Summary
- add Harmony message generation to the query transformation prompt while retaining the legacy template fallback
- seed the pipeline context with the active query and expose configuration so Harmony-aware LLMs receive multi-turn context
- extend configuration, documentation, and tests to cover the new Harmony defaults and explicit legacy compatibility

## Testing
- pytest pandasai/tests/unit_tests/helpers/test_query_transformer_llm.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfabfbfb483238ade6915d8be81bb