### PR TITLE
Add agent pipeline telemetry hooks and audit documentation

### DIFF
--- a/pandasai/docs/agent_pipeline_audit.md
+++ b/pandasai/docs/agent_pipeline_audit.md
@@ -1,0 +1,73 @@
+# Agent Chat Pipeline Audit
+
+## 1. Theory of Operation
+
+### 1.1 Entry point and pre-flight checks
+1. `Agent.chat()` receives the user query, logs it, creates a prompt id, screens for security keywords, and packages the conversation metadata into `ChatPipelineInput` before invoking the pipeline.【F:pandasai/pandasai/agent/base.py†L244-L274】
+2. Clarification flows use the same retry-aware `call_llm_with_prompt` helper; when explicitly triggered, the agent emits a clarification prompt, validates the JSON response, and keeps at most three follow-up questions.【F:pandasai/pandasai/agent/base.py†L215-L417】
+
+### 1.2 Code generation pipeline
+1. The `GenerateChatPipeline` wires the generation stages: validation, cache lookup, prompt construction, code generation, cache population, and code cleaning. Each logic unit can be skipped or retried depending on context flags set in `PipelineContext` (e.g., cache hits and existing code).【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L55-L168】
+2. When code cleaning or execution fails, the same `on_code_retry` hook reruns an error-correction pipeline that rebuilds the prompt and code, while recording the last exception type and the return kind for observability.【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L160-L168】【F:pandasai/pandasai/pipelines/chat/error_correction_pipeline/error_correction_pipeline.py†L33-L48】
+
+### 1.3 Code execution pipeline
+1. The execution pipeline chains `CodeExecution`, `ResultValidation`, and `ResultParsing`, resetting intermediate context and tracking each step for telemetry every time it runs.【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L79-L93】【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L237-L294】
+2. `CodeExecution.execute` retries generated code until either a valid `{type, value}` dictionary is produced or the configured `max_retries` limit is hit. Each failure logs the stack trace, notifies callbacks, and (if allowed) dispatches the error-correction pipeline via `_retry_run_code`, which now also records every attempt in `_error_correction_attempts` for inspection.【F:pandasai/pandasai/pipelines/chat/code_execution.py†L68-L135】【F:pandasai/pandasai/pipelines/chat/code_execution.py†L326-L363】
+3. Successful executions serialize the response for tracking and let downstream validation confirm the declared output schema against runtime values.【F:pandasai/pandasai/pipelines/chat/code_execution.py†L129-L135】【F:pandasai/pandasai/helpers/output_validator.py†L10-L69】
+
+### 1.4 Result parsing and memory updates
+1. `ResultValidation` logs mismatches and preserves the raw result in context memory even if schema validation fails.【F:pandasai/pandasai/pipelines/chat/result_validation.py†L21-L46】
+2. `ResultParsing` now toggles `_result_parsing_executed` in the pipeline context and pushes structured answers back into the conversation memory before formatting the final payload via the configured response parser.【F:pandasai/pandasai/pipelines/chat/result_parsing.py†L27-L69】
+
+## 2. Decision Graph
+
+The following state machine summarises the end-to-end flow, including guards and failure modes. Each transition references the code that enforces it.
+
+| State | Description | Transitions & Guards | Failure Mode |
+| --- | --- | --- | --- |
+| S0 | `Agent.chat()` accepts query, logs metadata, checks security keywords.【F:pandasai/pandasai/agent/base.py†L244-L274】 | `S0 → S1` if security passes; otherwise raise `MaliciousQueryError` and return error string.【F:pandasai/pandasai/agent/base.py†L262-L279】 | Returns templated error without pipeline execution. |
+| S1 | Validate context & cache lookup (`ValidatePipelineInput`, `CacheLookup`).【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L55-L71】 | `S1 → S2` after cache check; skip downstream generators if hit (`is_cached`).【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L63-L74】 | Invalid SQL/direct-sql config raises `InvalidConfigError`. |
+| S2 | Prompt & code generation, cache population, code cleaning.【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L62-L75】 | `S2 → S3` with generated/cleaned code. `S2 → S2` via error-correction pipeline when code cleaning fails (guard: `on_code_retry`).【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L160-L168】 | Exceptions propagate to final handler, returning formatted error string.【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L354-L367】 |
+| S3 | Code execution attempts with retry loop and optional error correction.【F:pandasai/pandasai/pipelines/chat/code_execution.py†L80-L127】 | `S3 → S4` when `OutputValidator.validate_result` succeeds. `S3 → S3` on retry guard `retry_count < max_retries` with correction pipeline output. `S3 → SF` when guard fails and exception re-raised.【F:pandasai/pandasai/pipelines/chat/code_execution.py†L109-L127】 | `SF`: exception bubbles to pipeline runner, generating fallback string and setting `last_error`.【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L348-L367】 |
+| S4 | Result validation ensures declared type/value alignment.【F:pandasai/pandasai/pipelines/chat/result_validation.py†L21-L46】 | `S4 → S5` always; warnings logged when mismatched. | None (warnings only). |
+| S5 | Result parsing, memory persistence, response formatting.【F:pandasai/pandasai/pipelines/chat/result_parsing.py†L27-L69】 | `S5 → Terminal` returning structured response. `_result_parsing_executed` flag confirms completion. | If parser raises, exception bubbles to fallback string in `GenerateChatPipeline.run`. |
+
+## 3. Fault Tree: Result Parsing Bypass after Error Correction
+
+### 3.1 Trigger conditions
+- Generated code returns a dictionary whose runtime value violates the declared `type`, raising `InvalidOutputValueMismatch` during execution validation.【F:pandasai/pandasai/pipelines/chat/code_execution.py†L96-L99】
+- `Config.use_error_correction_framework` is `True` and `max_retries` is finite. Each failure triggers `_retry_run_code`, which records the attempt and feeds the error-correction pipeline, but the LLM keeps emitting the same invalid code.【F:pandasai/pandasai/pipelines/chat/code_execution.py†L109-L127】【F:pandasai/pandasai/pipelines/chat/code_execution.py†L326-L363】
+- Once `retry_count >= max_retries`, `CodeExecution.execute` re-raises the last exception, preventing `ResultValidation`/`ResultParsing` from running.【F:pandasai/pandasai/pipelines/chat/code_execution.py†L109-L127】
+
+### 3.2 Observable outcome
+- The top-level pipeline catches the exception, records `last_error`, and emits the templated fallback string without engaging the result parser. `_result_parsing_executed` remains `False` because the parsing stage never ran.【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L348-L367】【F:pandasai/pandasai/pipelines/chat/result_parsing.py†L27-L49】
+- Instrumented reproduction using a fake LLM that always returns `{'type': 'string', 'value': 5}` shows two error-correction attempts logged in `_error_correction_attempts`, the fallback response string, and the untouched parsing flag.【a9bec6†L1-L20】
+
+### 3.3 Fault tree summary
+1. **Invalid result shape** → raises `InvalidOutputValueMismatch`.
+2. **Error-correction active?**
+   - **No** → immediate exception → fallback string.
+   - **Yes** → `_retry_run_code` invoked.
+3. **Correction produces valid code?**
+   - **Yes** → pipeline resumes normal path to `ResultParsing`.
+   - **No** → retry counter increments.
+4. **Retries exhausted?**
+   - **No** → loop continues (return to step 2).
+   - **Yes** → exception re-raised → fallback string (bypass `ResultParsing`).
+
+### 3.4 Root cause and scope
+- The fallback path is part of the upstream implementation; our diffs only add telemetry hooks (`_result_parsing_executed`, `_error_correction_attempts`, last correction metadata).【467a43†L1-L23】【706bae†L1-L8】【64fa6e†L1-L6】
+- Therefore, the bypass behaviour predates local modifications; it is inherited from the remote repository state (commit `0406093` lineage).
+
+## 4. Structured Diff Strategy & Findings
+
+- Compared the current branch with `HEAD~1` to ensure no behavioural regressions were introduced locally; only observability hooks were added, confirming parity with upstream error-handling semantics.【467a43†L1-L23】【706bae†L1-L8】【64fa6e†L1-L6】
+- Instrumented context keys (`_result_parsing_executed`, `_error_correction_attempts`, `_last_error_correction_*`) provide low-noise probes for tracing the decision graph in live runs without altering control flow.【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L160-L311】【F:pandasai/pandasai/pipelines/chat/code_execution.py†L326-L358】【F:pandasai/pandasai/pipelines/chat/result_parsing.py†L27-L49】
+
+## 5. Remediation Plan (Minimal Surface Area)
+
+1. **Standardise error payloads**: Convert terminal exceptions in `GenerateChatPipeline.run` into structured `{"type": "string", "value": <message>}` dictionaries and route them through `ResultValidation`/`ResultParsing` before returning. This keeps memory, telemetry, and response formatting consistent while preserving the existing error copy.【F:pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py†L348-L367】
+2. **Short-circuit repeated invalid outputs**: In `CodeExecution.execute`, detect identical `InvalidOutputValueMismatch` failures across retries (using `_error_correction_attempts`) and break early with a structured error result instead of exhausting all retries. This prevents redundant LLM calls when the correction framework is unlikely to succeed.【F:pandasai/pandasai/pipelines/chat/code_execution.py†L80-L135】【F:pandasai/pandasai/pipelines/chat/code_execution.py†L326-L358】
+3. **Optional safeguard**: Emit a warning when `_result_parsing_executed` remains `False` so downstream systems can alert on bypassed parsing events; instrumentation already exposes the flag, so the change is limited to logging/metrics wiring.【F:pandasai/pandasai/pipelines/chat/result_parsing.py†L27-L49】
+
+These changes are surgical, avoid large refactors, and ensure that even error responses traverse the same post-processing surfaces required for consistent analytics and memory management.

--- a/pandasai/pandasai/pipelines/chat/code_execution.py
+++ b/pandasai/pandasai/pipelines/chat/code_execution.py
@@ -342,6 +342,21 @@ class CodeExecution(BaseLogicUnit):
 
         Returns (str): A python code
         """
+        if context is not None:
+            attempts = context.get("_error_correction_attempts", [])
+            if not isinstance(attempts, list):
+                attempts = []
+            else:
+                attempts = attempts.copy()
+            attempts.append(
+                {
+                    "source": self.__class__.__name__,
+                    "exception": e.__class__.__name__,
+                    "message": str(e),
+                }
+            )
+            context.add("_error_correction_attempts", attempts)
+
         if self.on_retry:
             return self.on_retry(code, e)
         else:

--- a/pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py
+++ b/pandasai/pandasai/pipelines/chat/generate_chat_pipeline.py
@@ -159,7 +159,13 @@ class GenerateChatPipeline:
 
     def on_code_retry(self, code: str, exception: Exception):
         correction_input = ErrorCorrectionPipelineInput(code, exception)
-        return self.code_exec_error_pipeline.run(correction_input)
+        self.context.add("_last_error_correction_exception", exception.__class__.__name__)
+        output = self.code_exec_error_pipeline.run(correction_input)
+        self.context.add(
+            "_last_error_correction_output_type",
+            output.__class__.__name__,
+        )
+        return output
 
     def no_code(self, context: PipelineContext):
         return context.get("last_code_generated") is None
@@ -185,6 +191,7 @@ class GenerateChatPipeline:
 
         # Reset intermediate values
         self.context.reset_intermediate_values()
+        self.context.add("_result_parsing_executed", False)
 
         # Start New Tracking for Query
         self.query_exec_tracker.start_new_track(input)
@@ -242,6 +249,7 @@ class GenerateChatPipeline:
 
         # Reset intermediate values
         self.context.reset_intermediate_values()
+        self.context.add("_result_parsing_executed", False)
 
         # Start New Tracking for Query
         self.query_exec_tracker.start_new_track(input)
@@ -299,6 +307,7 @@ class GenerateChatPipeline:
 
         # Reset intermediate values
         self.context.reset_intermediate_values()
+        self.context.add("_result_parsing_executed", False)
 
         # Start New Tracking for Query
         self.query_exec_tracker.start_new_track(input)

--- a/pandasai/pandasai/pipelines/chat/result_parsing.py
+++ b/pandasai/pandasai/pipelines/chat/result_parsing.py
@@ -41,6 +41,9 @@ class ResultParsing(BaseLogicUnit):
 
         result = input
 
+        # Instrumentation hook: mark when result parsing executes.
+        pipeline_context.add("_result_parsing_executed", True)
+
         self._add_result_to_memory(result=result, context=pipeline_context)
 
         parser = self.response_parser(pipeline_context, logger=kwargs.get("logger"))


### PR DESCRIPTION
## Summary
- add lightweight telemetry hooks around code execution retries and result parsing to trace error-correction behaviour
- document the end-to-end Agent chat pipeline, decision graph, bypass fault tree, and remediation guidance in `docs/agent_pipeline_audit.md`

## Testing
- PYTHONPATH=pandasai python - <<'PY' ... (see logs for reproduction of the error-correction fallback path)

------
https://chatgpt.com/codex/tasks/task_e_68de25b873a083238cd05b0ffc0f1532